### PR TITLE
Use special strings for methodSig to handle contract call by pre-compiled ABI data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/coinbase/rosetta-sdk-go v0.8.2
 	github.com/ethereum/go-ethereum v1.13.8
-	github.com/holiman/uint256 v1.2.4
 	github.com/neilotoole/errgroup v0.1.6
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.17.0
@@ -49,6 +48,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/holiman/uint256 v1.2.4 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect

--- a/services/construction/contract_call_data.go
+++ b/services/construction/contract_call_data.go
@@ -92,28 +92,23 @@ func ConstructContractCallDataGeneric(methodSig string, methodArgs interface{}) 
 // preprocessArgs converts methodArgs to a string value if methodSig is an empty string.
 // We are calling a contract written with fallback pattern, which has no method signature.
 func preprocessArgs(methodSig string, methodArgs interface{}) (interface{}, error) {
-	if methodSig != "" && methodSig != NoMethodSig {
-		return methodArgs, nil
-	}
-
-	switch args := methodArgs.(type) {
-	case []interface{}:
-		if len(args) == 1 {
-			argStr, isStrVal := args[0].(string)
-			if !isStrVal {
+	if methodSig == "" || methodSig == NoMethodSig {
+		switch args := methodArgs.(type) {
+		case []interface{}:
+			if len(args) == 1 {
+				if argStr, ok := args[0].(string); ok {
+					return argStr, nil
+				}
 				return nil, fmt.Errorf("failed to convert method arg \"%T\" to string", args[0])
 			}
-			return argStr, nil
+		case []string:
+			if len(args) == 1 {
+				return args[0], nil
+			}
 		}
-		return methodArgs, nil
-	case []string:
-		if len(args) == 1 {
-			return args[0], nil
-		}
-		return methodArgs, nil
-	default:
-		return methodArgs, nil
 	}
+
+	return methodArgs, nil
 }
 
 // encodeMethodArgsStrings constructs the data field of a transaction for a list of string args.

--- a/services/construction/contract_call_data.go
+++ b/services/construction/contract_call_data.go
@@ -58,6 +58,16 @@ func ConstructContractCallDataGeneric(methodSig string, methodArgs interface{}) 
 
 	// case 2: method args are a list of interface{} which will be converted to string before encoding
 	case []interface{}:
+		if strings.HasPrefix(methodSig, "0x") && len(methodArgs) == 1 {
+			methodArgStr, _ := methodArgs[0].(string)
+			log.Printf("methodArgs is an interface array with length 1: %s", methodArgStr)
+			txData := strings.TrimPrefix(methodArgStr, "0x")
+			b, decErr := hex.DecodeString(txData)
+			if decErr != nil {
+				return nil, fmt.Errorf("error decoding method args hex data: %w", decErr)
+			}
+			return append(data, b...), nil
+		}
 		var strList []string
 		for i, genericVal := range methodArgs {
 			strVal, isStrVal := genericVal.(string)

--- a/services/construction/contract_call_data_test.go
+++ b/services/construction/contract_call_data_test.go
@@ -51,10 +51,15 @@ func TestConstruction_ContractCallData(t *testing.T) {
 			methodArgs:       []interface{}{"bool abc", "0x0000000000000000000000000000000000000000", "true"},
 			expectedResponse: "0x60d7a2780000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008626f6f6c20616263000000000000000000000000000000000000000000000000",
 		},
-		"happy path: method sig is hex string and args is a list of interface": {
-			methodSig:        "0xabcdef12",
-			methodArgs:       []interface{}{"34567890"},
-			expectedResponse: "0xabcdef1234567890",
+		"happy path: method sig is an empty string and args is a list of interface": {
+			methodSig:        "",
+			methodArgs:       []interface{}{"0xabcde12345"},
+			expectedResponse: "0xabcde12345",
+		},
+		"happy path: method sig is NO-METHOD-SIG and args is a list of interface": {
+			methodSig:        NoMethodSig,
+			methodArgs:       []interface{}{"0xaabbcc112233"},
+			expectedResponse: "0xaabbcc112233",
 		},
 		"error: case string: invalid method args hex data": {
 			methodSig:     "attest((bytes32,(address,uint64,bool,bytes32,bytes,uint256)))",
@@ -102,29 +107,29 @@ func TestConstruction_preprocessArgs(t *testing.T) {
 				"0",
 				"0x"},
 		},
-		"happy path: method sig is hex string and args is nil": {
-			methodSig:        "0xabcdef12",
+		"happy path: method sig is empty and args is nil": {
+			methodSig:        "",
 			methodArgs:       nil,
 			expectedResponse: nil,
 		},
-		"happy path: method sig is hex string and args is a single string": {
-			methodSig:        "0xabcdef12",
-			methodArgs:       "34567890",
-			expectedResponse: "34567890",
+		"happy path: method sig is NO-METHOD-SIG and args is a single string": {
+			methodSig:        NoMethodSig,
+			methodArgs:       "0x12345",
+			expectedResponse: "0x12345",
 		},
-		"happy path: method sig is hex string and args is a list of interface": {
-			methodSig:        "0xabcdef12",
-			methodArgs:       []interface{}{"34567890"},
-			expectedResponse: "34567890",
+		"happy path: method sig is empty and args is a list of interface": {
+			methodSig:        "",
+			methodArgs:       []interface{}{"0xabcde"},
+			expectedResponse: "0xabcde",
 		},
-		"happy path: method sig is hex string and args is a list of strings": {
-			methodSig:        "0xabcdef12",
-			methodArgs:       []string{"34567890"},
-			expectedResponse: "34567890",
+		"happy path: method sig is NO-METHOD-SIG and args is a list of strings": {
+			methodSig:        NoMethodSig,
+			methodArgs:       []string{"0x1a2b3c"},
+			expectedResponse: "0x1a2b3c",
 		},
 		"unhappy path: args is a list of interface and cannot be converted to strings": {
-			methodSig:     "0xabcdef12",
-			methodArgs:    []interface{}{34567890},
+			methodSig:     "",
+			methodArgs:    []interface{}{34567},
 			expectedError: errors.New("failed to convert method arg \"int\" to string"),
 		},
 	}


### PR DESCRIPTION
### Motivation
This PR is to add some logic to the preprocess API to handle fallback pattern contract call. This type of contract call does not have a method signature.

### Solution
We will use either empty string or a unique string "NO-METHOD-SIG" to indicate it. The pre-compiled ABI data will be passed in as methodArgs, either in the string format or the first element of an array.

### Testing

- Tested Preprocess API locally by passing empty string and "NO-METHOD-SIG" as methodSig.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
