### PR TITLE
feat(header forwarding): forward headers to native node requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net/http"
 	"strconv"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
@@ -59,8 +60,8 @@ type SDKClient struct {
 }
 
 // NewClient creates a client that connects to the network.
-func NewClient(cfg *configuration.Configuration, rpcClient *RPCClient) (*SDKClient, error) {
-	c, err := NewRPCClient(cfg.GethURL)
+func NewClient(cfg *configuration.Configuration, rpcClient *RPCClient, transport http.RoundTripper) (*SDKClient, error) {
+	c, err := NewRPCClient(cfg.GethURL, transport)
 	if err != nil {
 		return nil, err
 	}

--- a/client/default.go
+++ b/client/default.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import "net/http"

--- a/client/default.go
+++ b/client/default.go
@@ -1,0 +1,16 @@
+package client
+
+import "net/http"
+
+func NewDefaultHTTPTransport() http.RoundTripper {
+	// Override transport idle connection settings
+	//
+	// See this conversation around why `.Clone()` is used here:
+	// https://github.com/golang/go/issues/26013
+	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
+	defaultTransport.IdleConnTimeout = DefaultIdleConnTimeout
+	defaultTransport.MaxIdleConns = DefaultMaxConnections
+	defaultTransport.MaxIdleConnsPerHost = DefaultMaxConnections
+
+	return defaultTransport
+}

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -66,19 +66,14 @@ const (
 )
 
 // NewRPCClient connects a SDKClient to the given URL.
-func NewRPCClient(endpoint string) (*RPCClient, error) {
-	// Override transport idle connection settings
-	//
-	// See this conversation around why `.Clone()` is used here:
-	// https://github.com/golang/go/issues/26013
-	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
-	defaultTransport.IdleConnTimeout = DefaultIdleConnTimeout
-	defaultTransport.MaxIdleConns = DefaultMaxConnections
-	defaultTransport.MaxIdleConnsPerHost = DefaultMaxConnections
+func NewRPCClient(endpoint string, transport http.RoundTripper) (*RPCClient, error) {
+	if transport == nil {
+		transport = NewDefaultHTTPTransport()
+	}
 
 	clientOptions := rpc.WithHTTPClient(&http.Client{
 		Timeout:   gethHTTPTimeout,
-		Transport: defaultTransport,
+		Transport: transport,
 	})
 	ctx := context.Background()
 	client, err := rpc.DialOptions(ctx, endpoint, clientOptions)

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -76,14 +76,12 @@ func NewRPCClient(endpoint string, transport http.RoundTripper) (*RPCClient, err
 		Transport: transport,
 	})
 	ctx := context.Background()
+
 	client, err := rpc.DialOptions(ctx, endpoint, clientOptions)
-	/*client, err := rpc.DialHTTPWithClient(endpoint, &http.Client{
-		Timeout:   gethHTTPTimeout,
-		Transport: defaultTransport,
-	})*/
 	if err != nil {
 		return nil, fmt.Errorf("unable to dial node: %w", err)
 	}
+
 	return &RPCClient{client}, nil
 }
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -121,6 +121,13 @@ type RosettaConfig struct {
 
 	// SupportCustomizedBlockBody indicates if the blockchain supports customized block body
 	SupportCustomizedBlockBody bool
+
+	// SupportHeaderForwarding indicates if rosetta should forward rosetta request headers to the
+	// native node, and forward native node response headers to the rosetta caller
+	SupportHeaderForwarding bool
+
+	// ForwardHeaders is the list of headers to forward to and from the native node
+	ForwardHeaders []string
 }
 
 type Token struct {

--- a/examples/ethereum/client/client.go
+++ b/examples/ethereum/client/client.go
@@ -165,7 +165,7 @@ func (c *EthereumClient) GetNativeTransferGasLimit(ctx context.Context, toAddres
 // Ethereum network.
 func NewEthereumClient(cfg *configuration.Configuration) (*EthereumClient, error) {
 	// Use SDK to quickly create a client that support JSON RPC calls
-	evmClient, err := evmClient.NewClient(cfg, nil)
+	evmClient, err := evmClient.NewClient(cfg, nil, nil)
 
 	if err != nil {
 		log.Fatalln("cannot initialize client: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.20
 
 require (
 	github.com/coinbase/rosetta-sdk-go v0.8.2
+	github.com/coinbase/rosetta-sdk-go/types v1.0.0
 	github.com/ethereum/go-ethereum v1.13.8
+	github.com/google/uuid v1.6.0
 	github.com/neilotoole/errgroup v0.1.6
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.17.0
@@ -44,7 +46,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
@@ -58,7 +59,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/coinbase/rosetta-geth-sdk
 go 1.20
 
 require (
-	github.com/coinbase/rosetta-sdk-go v0.8.2
+	github.com/coinbase/rosetta-sdk-go v0.8.6
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0
 	github.com/ethereum/go-ethereum v1.13.8
-	github.com/google/uuid v1.6.0
 	github.com/neilotoole/errgroup v0.1.6
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.17.0
@@ -46,6 +45,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
-github.com/coinbase/rosetta-sdk-go v0.8.2 h1:+sNgMUPpntOsYLy5aRsHqBY6I0MTxZkS4JXV1Un3DKc=
-github.com/coinbase/rosetta-sdk-go v0.8.2/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
+github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
+github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/gnark-crypto v0.12.1 h1:lHH39WuuFgVHONRl3J0LRBtuYdQTumFSDtJF7HpyG8M=
@@ -242,8 +242,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -340,8 +340,8 @@ github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQ
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
+github.com/coinbase/rosetta-sdk-go v0.8.6 h1:FQ8ApWTZIsung1AsTv+DjXR7RwKnS6MQXzLcXtBNyjc=
+github.com/coinbase/rosetta-sdk-go v0.8.6/go.mod h1:LD9qAq1m+pwAqEBrzNTjDy9VTYEDgeHiiltVTVyHfXI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -1,0 +1,15 @@
+package headers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// TODO: filter headers by "interesting headers"
+func ContextWithHeaders(r *http.Request) context.Context {
+	ctx := r.Context()
+	ctxWithHeaders := rpc.NewContextWithHeaders(ctx, r.Header)
+	return ctxWithHeaders
+}

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package headers
 
 import (

--- a/services/router.go
+++ b/services/router.go
@@ -15,9 +15,11 @@
 package services
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
+	"github.com/coinbase/rosetta-geth-sdk/headers"
 	AssetTypes "github.com/coinbase/rosetta-geth-sdk/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
@@ -33,43 +35,53 @@ func NewBlockchainRouter(
 	types *AssetTypes.Types,
 	errors []*types.Error,
 	client construction.Client,
-
 	asserter *asserter.Asserter,
 ) http.Handler {
+	var contextFromRequest func(r *http.Request) context.Context = nil
+	if config.RosettaCfg.SupportHeaderForwarding {
+		contextFromRequest = headers.ContextWithHeaders
+	}
+
 	networkAPIService := NewNetworkAPIService(config, types, errors, client)
 	networkAPIController := server.NewNetworkAPIController(
 		networkAPIService,
 		asserter,
+		contextFromRequest,
 	)
 
 	accountAPIService := NewAccountAPIService(config, types, errors, client)
 	accountAPIController := server.NewAccountAPIController(
 		accountAPIService,
 		asserter,
+		contextFromRequest,
 	)
 
 	blockAPIService := NewBlockAPIService(config, client)
 	blockAPIController := server.NewBlockAPIController(
 		blockAPIService,
 		asserter,
+		contextFromRequest,
 	)
 
 	constructionAPIService := construction.NewAPIService(config, types, errors, client)
 	constructionAPIController := server.NewConstructionAPIController(
 		constructionAPIService,
 		asserter,
+		contextFromRequest,
 	)
 
 	// mempoolAPIService := NewMempoolAPIService()
 	// mempoolAPIController := server.NewMempoolAPIController(
 	// 	mempoolAPIService,
 	// 	asserter,
+	//  contextFromRequest,
 	// )
 
 	// callAPIService := NewCallAPIService(config, client)
 	// callAPIController := server.NewCallAPIController(
 	// 	callAPIService,
 	// 	asserter,
+	//  contextFromRequest,
 	// )
 
 	return server.NewRouter(


### PR DESCRIPTION
### Motivation

In order to support some common use cases, Mesh servers need the ability to pass request headers through to the native nodes, and to return headers from native node requests back to the caller.

Use cases:
* **passing a client ID header to the nodes** — this client ID shouldn't originate with the Mesh server since it may have many different callers, so it should be passed through to the native node requests
* **sticky session cookies** — to support sticky sessions on native nodes, AWS uses cookies. Cookies are managed by the `Cookie` and `Set-Cookie` headers, which will need to be passed from the caller to the native node, and returned from the native node ALB to the caller

### Solution

This PR adds a utility, `ContextWithHeaders` which uses `context` to inject headers into rpc requests created by `go-ethereum` (https://github.com/ethereum/go-ethereum/pull/26023)

It also adds two forms of plumbing:
1. a `contextFromRequest` method in all controllers — this allows users of `mesh-geth-sdk` to use the context to add headers to outgoing native node requests
2. middleware applied to the whole server — this allows users of `mesh-geth-sdk` to add headers to the Mesh response, possibly using a utility like `HeaderForwarder` from https://github.com/coinbase/mesh-sdk-go/pull/507

### Open questions

no open questions
