### PR TITLE
Improve caching of contract currency details

### DIFF
--- a/client/utils.go
+++ b/client/utils.go
@@ -16,9 +16,9 @@ package client
 
 import (
 	"encoding/json"
+	"log"
 	"math/big"
 	"strings"
-	"log"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 
@@ -166,6 +166,17 @@ func IsValidERC20Token(whiteList []configuration.Token, address string) bool {
 	return false
 }
 
+// GetValidERC20Token checks if the token is in whitelist and returns the token info if found
+func GetValidERC20Token(whiteList []configuration.Token, address string) *configuration.Token {
+	for _, token := range whiteList {
+		// EqualFoldContains checks if the array contains the string regardless of casing
+		if strings.EqualFold(token.Address, address) {
+			return &token
+		}
+	}
+	return nil
+}
+
 func GenerateErc20TransferData(toAddress string, value *big.Int) []byte {
 	to := common.HexToAddress(toAddress)
 	methodID := getTransferMethodID()
@@ -181,7 +192,7 @@ func GenerateErc20TransferData(toAddress string, value *big.Int) []byte {
 }
 
 func (tx *LoadedTransaction) GetMint() *big.Int {
-	if  tx.Mint == "" {
+	if tx.Mint == "" {
 		return big.NewInt(0)
 	}
 	hexString := tx.Mint[2:]

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -100,6 +100,9 @@ type RosettaConfig struct {
 	// TokenWhiteList is a list of ERC20 tokens we only support
 	TokenWhiteList []Token
 
+	// UseTokenWhiteListMetadata indicates whether we use token metadata from token white list or fetch from nodes
+	UseTokenWhiteListMetadata bool
+
 	// DefaultBlockNumber is the default block number if block identifier is not specified
 	// This is mainly used for Optimism and Base, it can be "safe" or "finalized" to avoid reorg issues
 	DefaultBlockNumber string

--- a/examples/ethereum/config/config.go
+++ b/examples/ethereum/config/config.go
@@ -97,6 +97,11 @@ const (
 	// using our token white list
 	TokenFilterEnv = "FILTER"
 
+	// UseTokenWhiteListMetadataEnv is the environment variable
+	// read to determine if we will use token metadata
+	// from the token white list or fetch from nodes
+	UseTokenWhiteListMetadataEnv = "USE_TOKEN_WHITE_LIST_METADATA"
+
 	// GethEnv is an optional environment variable
 	// used to connect rosetta-ethereum to an already
 	// running geth node.
@@ -234,6 +239,13 @@ func LoadConfiguration() (*configuration.Configuration, error) {
 		return nil, fmt.Errorf("unable to parse token filter %t: %w", tokenFilterValue, err)
 	}
 
+	useTokenWhiteListMetadataValue := false
+	if val := os.Getenv(UseTokenWhiteListMetadataEnv); val != "" {
+		if v, err := strconv.ParseBool(val); err == nil {
+			useTokenWhiteListMetadataValue = v
+		}
+	}
+
 	payload := []configuration.Token{}
 	config.RosettaCfg = configuration.RosettaConfig{
 		SupportRewardTx: true,
@@ -242,9 +254,10 @@ func LoadConfiguration() (*configuration.Configuration, error) {
 			Symbol:   "ETH",
 			Decimals: 18,
 		},
-		TracePrefix:    "",
-		FilterTokens:   tokenFilterValue,
-		TokenWhiteList: payload,
+		TracePrefix:               "",
+		FilterTokens:              tokenFilterValue,
+		UseTokenWhiteListMetadata: useTokenWhiteListMetadataValue,
+		TokenWhiteList:            payload,
 	}
 
 	return config, nil

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.8.6
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0
 	github.com/ethereum/go-ethereum v1.13.8
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/neilotoole/errgroup v0.1.6
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 h1:3JQNjnMRil1yD0IfZKHF9GxxWKDJGj8I0IqOUol//sw=

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -133,6 +133,7 @@ func (s *BlockAPIService) PopulateTransaction(
 	}
 
 	filterTokens := s.client.GetRosettaConfig().FilterTokens
+	tokenWhiteList := s.client.GetRosettaConfig().TokenWhiteList
 	useTokenWhiteListMetadata := s.client.GetRosettaConfig().UseTokenWhiteListMetadata
 	indexUnknownTokens := s.config.RosettaCfg.IndexUnknownTokens
 
@@ -154,7 +155,7 @@ func (s *BlockAPIService) PopulateTransaction(
 
 		if filterTokens {
 			// Check whitelist first if filtering is enabled
-			tokenInfo := client.GetValidERC20Token(s.client.GetRosettaConfig().TokenWhiteList, contractAddress)
+			tokenInfo := client.GetValidERC20Token(tokenWhiteList, contractAddress)
 			if tokenInfo == nil {
 				continue // Token not in whitelist
 			}

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"strings"
 
 	goEthereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -96,15 +95,6 @@ func (s *BlockAPIService) populateTransactions(
 	return transactions, nil
 }
 
-func getWhitelistedToken(whitelist []configuration.Token, address string) *configuration.Token {
-	for _, token := range whitelist {
-		if strings.EqualFold(token.Address, address) {
-			return &token
-		}
-	}
-	return nil
-}
-
 func (s *BlockAPIService) PopulateTransaction(
 	ctx context.Context,
 	tx *client.LoadedTransaction,
@@ -156,7 +146,7 @@ func (s *BlockAPIService) PopulateTransaction(
 				addressStr := log.Address.String()
 
 				// Check if token is whitelisted
-				tokenInfo := getWhitelistedToken(s.client.GetRosettaConfig().TokenWhiteList, addressStr)
+				tokenInfo := client.GetValidERC20Token(s.client.GetRosettaConfig().TokenWhiteList, addressStr)
 				if tokenInfo == nil {
 					// Token not in whitelist
 					continue


### PR DESCRIPTION
### Fixes
Improve caching of contract currency details.

### Motivation
To improve /block latency. A major bottleneck is that contractCurrencyMap is created fresh for each transaction, so it only caches within a single transaction's logs. That's why we see repeated GetContractCurrency calls for the same contracts across different transactions.

### Solution
Add an LRU cache that stores contract currency details across blocks. Also, don't go to the node for allow listed tokens to get symbol and decimals (if env var USE_TOKEN_WHITE_LIST_METADATA="true"), as they can be retrieved from the config.