### PR TITLE
fix: Made withdrawal validation optional and configurable

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -79,6 +79,9 @@ type RosettaConfig struct {
 	// SupportsEIP1559 indicates if the blockchain supports EIP-1559
 	SupportsEIP1559 bool
 
+	// SupportsWithdrawals indicates if the blockchain supports EIP-4895 (withdrawals)
+	SupportsWithdrawals bool
+
 	// SupportsOpStack indicates if the blockchain supports OP stack
 	SupportsOpStack bool
 

--- a/services/validator/ethereum_validator.go
+++ b/services/validator/ethereum_validator.go
@@ -333,6 +333,10 @@ func (v *trustlessValidator) validateWithdrawals(
 	withdrawals EthTypes.Withdrawals,
 	withdrawalsRoot *geth.Hash,
 ) error {
+	if true { // TODO: make this check if its an L2
+		return nil
+	}
+
 	if withdrawalsRoot == nil {
 		// if the withdrawalsRoot is nil, we expect the withdrawals to be empty
 		if len(withdrawals) != 0 {

--- a/services/validator/ethereum_validator.go
+++ b/services/validator/ethereum_validator.go
@@ -333,7 +333,8 @@ func (v *trustlessValidator) validateWithdrawals(
 	withdrawals EthTypes.Withdrawals,
 	withdrawalsRoot *geth.Hash,
 ) error {
-	if true { // TODO: make this check if its an L2
+	// only validate withdrawals if the blockchain supports withdrawals (EIP-4895)
+	if !v.config.RosettaCfg.SupportsWithdrawals {
 		return nil
 	}
 


### PR DESCRIPTION
### Motivation
Unichain does not support EIP-4895, as do a number of other chains. This means that while their withdrawal root is computed as if there are withdrawals, none are being returned to us via RPC. We just need to skip withdrawal validation for them and any other chains who operate similarly.

### Solution
Create a new parameter in the RosettaConfig `SupportsWithdrawals` that toggle our withdrawal validation.

### Open questions
Is there any consistent way to check if a chain supports withdrawals?